### PR TITLE
working CASSANDRA_YAML_ envvars, force lowercase

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -33,8 +33,8 @@ ENV \
     CASSANDRA_CONF=/etc/cassandra \
     CASSANDRA_DATA=/var/lib/cassandra \
     CASSANDRA_LOGS=/var/log/cassandra \
-    CASSANDRA_RELEASE=3.11.3 \
-    CASSANDRA_SHA=d82e0670cb41b091e88fff55250ce945c4ea026c87a5517d3cf7b6b351d5e2ba \
+    CASSANDRA_RELEASE=3.11.4 \
+    CASSANDRA_SHA=5d598e23c3ffc4db0301ec2b313061e3208fae0f9763d4b47888237dd9069987 \
     JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 \
     DI_VERSION=1.2.1 \
     DI_SHA=057ecd4ac1d3c3be31f82fc0848bf77b1326a975b4f8423fe31607205a0fe945 \

--- a/container/README.md
+++ b/container/README.md
@@ -50,7 +50,11 @@ files folder as well.
 
 Besides the base values one can pass in Environment Variables that named with
 the prefix `CASSANDRA_YAML_`.  Any env var with that prefix is parsed and the value
-sets the corresponding YAML value in the `cassandra.yaml` configuration file.
+sets the corresponding YAML value in the `cassandra.yaml` configuration file, even
+if that line did not exist firsthand.
+Worth noting is that `CASSANDRA_YAML_FOO_BAR=baz` and `CASSANDRA_YAML_foo_bar=baz` will yield the
+same resulting line `foo_bar: baz` within the configuration file, as lowercase characters are enforced
+on configuration keys.
 
 For example:
 

--- a/container/files/run.sh
+++ b/container/files/run.sh
@@ -130,6 +130,9 @@ fi
 if [ -n "$CASSANDRA_REPLACE_NODE" ]; then
    echo "-Dcassandra.replace_address=$CASSANDRA_REPLACE_NODE/" >> "$CASSANDRA_CONF_DIR/jvm.options"
 fi
+if [ -n "$CASSANDRA_REPLACE_ADDRESS_FIRST_BOOT" ]; then
+   echo "-Dcassandra.replace_address_first_boot=$CASSANDRA_REPLACE_ADDRESS_FIRST_BOOT/" >> "$CASSANDRA_CONF_DIR/jvm.options"
+fi
 
 # Setup C* racks
 # Add rack
@@ -188,9 +191,9 @@ done
 # "phi_convict_threshold: 10".
 while read -r envname ; do
   if [[ $envname == 'CASSANDRA_YAML_'* ]]; then
-    name=$(echo ${envname}| sed s/CASSANDRA_YAML_//g | cut -d= -f 1 | sed -e 's/\(.*\)/\L\1/')
-    val=$(echo ${envname}|cut -d= -f 2)
-    if grep $name $CASSANDRA_CFG;then
+    name=$(echo "${envname}"| sed s/CASSANDRA_YAML_//g | cut -d= -f 1 | sed -e 's/\(.*\)/\L\1/')
+    val=$(echo "${envname}"|cut -d= -f 2)
+    if grep "$name" "$CASSANDRA_CFG";then
         echo "FOUND $name $val"
         sed -ri 's/^(#\s*)?('"$name"':).*/\2 '"$val"'/' "$CASSANDRA_CFG"
     else

--- a/container/files/run.sh
+++ b/container/files/run.sh
@@ -191,8 +191,8 @@ while read -r envname ; do
     name=$(echo ${envname}| sed s/CASSANDRA_YAML_//g | cut -d= -f 1 | sed -e 's/\(.*\)/\L\1/')
     val=$(echo ${envname}|cut -d= -f 2)
     if grep $name $CASSANDRA_CFG;then
-        echo "FOUND $name $yaml $val"
-        sed -ri 's/^(#\s*)?('"$yaml"':).*/\2 '"$val"'/' "$CASSANDRA_CFG"
+        echo "FOUND $name $val"
+        sed -ri 's/^(#\s*)?('"$name"':).*/\2 '"$val"'/' "$CASSANDRA_CFG"
     else
         echo "NOT FOUND $name, appending to $CASSANDRA_CFG"
         echo "$name: $val" >> $CASSANDRA_CFG


### PR DESCRIPTION
This change makes CASSANDRA_YAML_* environment variables work, and enforces lowercase to the parameter name.